### PR TITLE
Add 'justify' as an option for text alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Features:
 - uses [word-wrapper](https://npmjs.com/package/word-wrapper) for layout
   - supports `"pre"` and `"nowrap"` modes (like CSS)
   - breaks on explicit newline characters `"\n"`
-- handles `"left"`, `"center"` and `"right"` alignments
+- handles `"left"`, `"center"`, `"right"` and `"justify"` alignments
 - handles kerning, letter spacing, line height
 - handles space and tab widths
 - provides computed bounds of resulting text box
@@ -57,7 +57,7 @@ Creates a new layout with the given options.
 - `text` (string) the text to layout. Newline characters (`\n`) will cause line breaks
 - `width` (number, optional) the desired width of the text box, causes word-wrapping and clipping in `"pre"` mode. Leave as undefined to remove word-wrapping (default behaviour)
 - `mode` (string) a mode for [word-wrapper](https://www.npmjs.com/package/word-wrapper); can be 'pre' (maintain spacing), or 'nowrap' (collapse whitespace but only break on newline characters), otherwise assumes normal word-wrap behaviour (collapse whitespace, break at width or newlines)
-- `align` (string) can be `"left"`, `"center"` or `"right"` (default: left)
+- `align` (string) can be `"left"`, `"center"`, `"right"` or `"justify"` (default: left)
 - `letterSpacing` (number) the letter spacing in pixels (default: 0)
 - `lineHeight` (number) the line height in pixels (default to `font.common.lineHeight`)
 - `tabSize` (number) the number of spaces to use in a single tab (default 4)

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ var TAB_ID = '\t'.charCodeAt(0)
 var SPACE_ID = ' '.charCodeAt(0)
 var ALIGN_LEFT = 0, 
     ALIGN_CENTER = 1, 
-    ALIGN_RIGHT = 2
+    ALIGN_RIGHT = 2,
+    ALIGN_JUSTIFY = 3
 
 module.exports = function createLayout(opt) {
   return new TextLayout(opt)
@@ -79,6 +80,20 @@ TextLayout.prototype.update = function(opt) {
     var end = line.end
     var lineWidth = line.width
     var lastGlyph
+    var extraSpaceSpacing = 0
+
+    if (align === ALIGN_JUSTIFY) {
+      var spaceCount = 0
+      for (var j=start; j<end; j++) {
+        var id = text.charCodeAt(j)
+        if (id === SPACE_ID)
+          spaceCount++
+      }
+      var extraSpace = maxLineWidth - lineWidth
+
+      if (spaceCount && extraSpace / maxLineWidth < 0.3)
+        extraSpaceSpacing = extraSpace / spaceCount
+    }
     
     //for each glyph in that line...
     for (var i=start; i<end; i++) {
@@ -93,6 +108,8 @@ TextLayout.prototype.update = function(opt) {
           tx += (maxLineWidth-lineWidth)/2
         else if (align === ALIGN_RIGHT)
           tx += (maxLineWidth-lineWidth)
+        else if (align === ALIGN_JUSTIFY && id === SPACE_ID)
+          x += extraSpaceSpacing
 
         glyphs.push({
           position: [tx, y],
@@ -285,6 +302,8 @@ function getAlignType(align) {
     return ALIGN_CENTER
   else if (align === 'right')
     return ALIGN_RIGHT
+  else if (align === 'justify')
+    return ALIGN_JUSTIFY
   return ALIGN_LEFT
 }
 


### PR DESCRIPTION
Spaces text so each line fills the entire width.

There is one area I'd like to suggest for future improvement, which is how trailing lines are handled. In my experience, you don't want to justify the last line of a paragraph. (See, for example, Star Wars opening crawls.) To implement this properly, we'd need to know whether each line was forced to wrap or ended naturally by EOL or EOF. But https://github.com/mattdesl/word-wrapper strips that information out. So for now, I've chosen to justify only lines that take up 70% of the line width.

If @mattdesl would like to make a change to include an additional boolean in the output of word-wrapper, I'd be happy to make another commit or PR here.