### PR TITLE
Add backward-compatible wordBreak option that follows css word-break rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Creates a new layout with the given options.
 - `text` (string) the text to layout. Newline characters (`\n`) will cause line breaks
 - `width` (number, optional) the desired width of the text box, causes word-wrapping and clipping in `"pre"` mode. Leave as undefined to remove word-wrapping (default behaviour)
 - `mode` (string) a mode for [word-wrapper](https://www.npmjs.com/package/word-wrapper); can be 'pre' (maintain spacing), or 'nowrap' (collapse whitespace but only break on newline characters), otherwise assumes normal word-wrap behaviour (collapse whitespace, break at width or newlines)
+- `wordBreak` (string) can be `"normal"`, `"break-all"`, `"keep-all"`, `"break-word"` (default: `break-all` for backwrad-compatability). Refer to [CSS word-break](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break) prop for how this would work.
 - `align` (string) can be `"left"`, `"center"` or `"right"` (default: left)
 - `letterSpacing` (number) the letter spacing in pixels (default: 0)
 - `lineHeight` (number) the line height in pixels (default to `font.common.lineHeight`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layout-bmfont-text",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "word-wraps and lays out text glyphs",
   "main": "index.js",
   "license": "MIT",
@@ -22,6 +22,7 @@
     "canvas-testbed": "^1.0.3",
     "clamp": "^1.0.1",
     "img": "^1.0.0",
+    "indexof-property": "^1.1.1",
     "lerp": "^1.0.3",
     "smoothstep": "^1.0.1",
     "tape": "^3.5.0",

--- a/test.js
+++ b/test.js
@@ -69,5 +69,65 @@ test('should export API', function(t) {
   t.deepEqual(layout.glyphs.map(function (x) {
     return x.index
   }), [ 0, 1, 3, 4 ], 'provides indices')
+
+  // Test limited width and test wordBreak options
+  // Default behavior of wordBreak;
+  layout = createLayout({
+    text: 'hello\nworld',
+    font: font,
+    width: 50,
+  })
+  t.deepEqual(layout.glyphs.map(function (x) {
+    return x.line
+  }), [ 0, 0, 0, 1, 1, 2, 2, 3, 3, 3 ], 'breaks all words by default')
+
+  // wordBreak: break-all (also default behavior)
+  layout = createLayout({
+    text: 'hello\nworld',
+    font: font,
+    width: 50,
+    wordBreak: 'break-all',
+  })
+  t.deepEqual(layout.glyphs.map(function (x) {
+    return x.line
+  }), [ 0, 0, 0, 1, 1, 2, 2, 3, 3, 3 ], 'wordBreak: break-all')
+
+
+  // wordBreak: normal
+  layout = createLayout({
+    text: 'line1\nline2 thiswrapsbutstaysone',
+    font: font,
+    width: 50,
+    wordBreak: 'normal',
+  })
+  
+  t.deepEqual(layout.glyphs.map(function (x) {
+    return x.line
+  }), [ 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ], 'wordBreak: normal')
+
+  // wordBreak: keep-all
+  layout = createLayout({
+    text: 'hello line1\nworld line2',
+    font: font,
+    width: 50,
+    wordBreak: 'keep-all',
+  })
+  
+  t.deepEqual(layout.glyphs.map(function (x) {
+    return x.line
+  }), [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ], 'wordBreak: keep-all')
+  
+    // wordBreak: break-word
+    layout = createLayout({
+      text: 'hel by a superlong',
+      font: font,
+      width: 50,
+      wordBreak: 'break-word',
+    })
+    
+    t.deepEqual(layout.glyphs.map(function (x) {
+      return x.line
+    }), [0, 0, 0, 1, 1, 2, 3, 3, 4, 4, 4, 5, 5, 5, 6 ], 'wordBreak: break-word')
+    
   t.end()
 })


### PR DESCRIPTION
Not sure if this will go in, the project doesn't seem to be active. But sending this anyway in case others ran into the same problem with clipping words as I did.

Also for those who wants to use this functionality I've published my own npm package. You can
```
npm i @mkhatib/layout-bmfont-text
# And if you use this through three-bmfont-text I've also published a version of that that uses this change.
npm i @mkhatib/three-bmfont-text
```

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [x] Also tested it within a project I was already using the package in with no problems
- [ ] I deeply tested it in several browsers
- [x] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

<!--- Describe the problem briefly or reference related issues -->

The library defaulted to `break-all` behavior when it ran out of space on the line. So A paragraph like this:
```
Hello World today is going to be beautiful
```

Would break into:
```
Hello W
orld tod
ay is goi
ng to be
beautiful
```

## Solution Description

<!--- Describe your changes in detail -->

I've added an option users can pass (that defaults to the old `break-all` behavior so not to break others. But now you can this can render like:

Would break into this with `normal`:
```
Hello 
World
today
is
going
to be
beautiful
```

Would break into this with `break-word` (only breaks the word if it can't fit on a line by itself):
```
Hello 
World
today
is
going
to be
beaut
iful
```

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [x] N/A

**Aditional comments:**
