### PR TITLE
made compliant with Content-Security-Policy unsafe-eval restrictions

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,30 +202,65 @@ TextLayout.prototype.computeMetrics = function(text, start, end, width) {
     end: start + count,
     width: curWidth
   }
-}
+};
 
-//getters for the private vars
-;['width', 'height', 
-  'descender', 'ascender',
-  'xHeight', 'baseline',
-  'capHeight',
-  'lineHeight' ].forEach(addGetter)
+// //getters for the private vars
+// ;['width', 'height', 
+//   'descender', 'ascender',
+//   'xHeight', 'baseline',
+//   'capHeight',
+//   'lineHeight' ].forEach(addGetter)
 
-function addGetter(name) {
-  Object.defineProperty(TextLayout.prototype, name, {
-    get: wrapper(name),
-    configurable: true
-  })
-}
+// function addGetter(name) {
+//   Object.defineProperty(TextLayout.prototype, name, {
+//     get: wrapper(name),
+//     configurable: true
+//   })
+// }
 
-//create lookups for private vars
-function wrapper(name) {
-  return (new Function([
-    'return function '+name+'() {',
-    '  return this._'+name,
-    '}'
-  ].join('\n')))()
-}
+// //create lookups for private vars
+// function wrapper(name) {
+//   return (new Function([
+//     'return function '+name+'() {',
+//     '  return this._'+name,
+//     '}'
+//   ].join('\n')))()
+// }
+
+// more tedious than the previous implementation, but compliant with
+// Content-Security-Policy
+Object.defineProperty(TextLayout.prototype, 'width', {
+  get: function() { return this._width },
+  configurable: true
+});
+Object.defineProperty(TextLayout.prototype, 'height', {
+  get: function() { return this._height },
+  configurable: true
+});
+Object.defineProperty(TextLayout.prototype, 'descender', {
+  get: function() { return this._descender },
+  configurable: true
+});
+Object.defineProperty(TextLayout.prototype, 'ascender', {
+  get: function() { return this._ascender },
+  configurable: true
+});
+Object.defineProperty(TextLayout.prototype, 'xHeight', {
+  get: function() { return this._xHeight },
+  configurable: true
+});
+Object.defineProperty(TextLayout.prototype, 'baseline', {
+  get: function() { return this._baseline },
+  configurable: true
+});
+Object.defineProperty(TextLayout.prototype, 'capHeight', {
+  get: function() { return this._capHeight },
+  configurable: true
+});
+Object.defineProperty(TextLayout.prototype, 'lineHeight', {
+  get: function() { return this._lineHeight },
+  configurable: true
+});
 
 function getGlyphById(font, id) {
   if (!font.chars || font.chars.length === 0)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "as-number": "^1.0.0",
+    "configurable": "^0.0.1",
+    "load-bmfont": "^1.4.1",
     "word-wrapper": "^1.0.7",
     "xtend": "^4.0.0"
   },
@@ -24,7 +26,7 @@
     "img": "^1.0.0",
     "lerp": "^1.0.3",
     "smoothstep": "^1.0.1",
-    "tape": "^3.5.0",
+    "tape": "^3.6.1",
     "touch-position": "^1.0.3",
     "uglify-js": "^2.4.17",
     "vectors": "^0.1.0",


### PR DESCRIPTION
This is a fix for [#30](https://github.com/Jam3/three-bmfont-text/issues/30), which would also fix https://github.com/aframevr/aframe/issues/5028.

Disabling inline scripts and unsafe-eval using Content-Security-Policy is a huge security win, stopping whole classes of attacks like XSS.

For more info on CSP, see:

* https://scotthelme.co.uk/content-security-policy-an-introduction/
* https://content-security-policy.com

The root cause for the breakage is the code:

```
//create lookups for private vars
function wrapper(name) {
  return (new Function([
    'return function '+name+'() {',
    '  return this._'+name,
    '}'
  ].join('\n')))()
}
```

which makes creating getters for private properties easy, but at the cost of doing a potentially unsafe implicit eval of a string. Allowing unsafe-eval in CSP works around that, at the expense of completely gutting XSS protections.

**What kind of change does this PR introduce?** (check at least one)

This PR simply unrolls the property getters to make them static, not dynamically evaluated. Tedious but safer, and there aren't *that many* private properties. Whether CSP compatibility is a bugfix or a feature is in the eye of the beholder, but many organizations will refuse to make exceptions to their CSP and thus would be unable to use this library or others that depend on it like A-Frame.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

It's simply unrolling the changes made by the wrapper.

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [X] I deeply tested it in several browsers
- [X] I wrote tests around it (unit tests, integration tests, E2E tests)

I tested it against A-Frame in Vivaldi, Firefox, Safari and the Oculus/Meta Browser on my Oculus Go.  I verified using the following Node.js script based on your example:

```
var createLayout = require('./')
var loadFont = require('load-bmfont')

loadFont('https://cdn.aframe.io/fonts/Aileron-Semibold.fnt', function(err, font) {
  var layout = createLayout({
    font: font,
    text: 'Lorem ipsum dolor\nsit amet',
    width: 300,
    letterSpacing: 2,
    align: 'center'
  })

  //for rendering
  console.log(layout.glyphs)

  //metrics
  console.log(layout.width, layout.height)
  console.log(layout.descender, layout.ascender)
})
```

## Problem Description

Make the library and its dependents compliant with Content-Security-Policy

## Solution Description

Replace unsafe-eval instances with unrolled equivalent code.

## Side Effects, Risks, Impact

- [X] N/A

Unlikely to be risky

**Aditional comments:**
